### PR TITLE
New feature on readInputTS() : read data on thermal outages

### DIFF
--- a/R/importInput.R
+++ b/R/importInput.R
@@ -108,6 +108,34 @@
   
 }
 
+
+.importThermalOutages <- function(area, timeStep, opts, ...) {
+  if (!area %in% opts$areasWithClusters) return(NULL)
+  
+  names <- c("FODuration", "PODuration", "FORate", "PORate", "NPOMin", "NPOMax")
+
+  
+  
+  clusters <- list.files(file.path(opts$inputPath, "thermal/series", area))
+  
+  ldply(clusters, function(cl) {
+    filePattern <- sprintf("%s/%s/%%s/data.txt", "thermal/prepro", area)
+    res <- .importInputTS(cl, timeStep, opts, filePattern,
+                          colnames = names,
+                          inputTimeStep = "daily", fun = "mean", type = "simple")
+    
+    if (is.null(res)) return(NULL)
+    
+    res$area <- area
+    res$cluster <- cl
+    setcolorder(res, c("area", "cluster", "timeId", setdiff(names(res), c("area", "cluster", "timeId"))))
+    
+    
+  })
+  
+}
+
+
 .importROR <- function(area, timeStep, opts, ...) {
   .importInputTS(area, timeStep, opts, "hydro/series/%s/ror.txt", "ror", 
                  inputTimeStep = "hourly", type = "matrix")

--- a/R/readInputTS.R
+++ b/R/readInputTS.R
@@ -11,6 +11,8 @@
 #'   vector of areas names for which load time series must be read.
 #' @param thermalAvailabilities
 #'   vector of areas names for which thermal availabilities of clusters must be read.
+#' @param thermalOutages
+#'   vector of areas names for which thermal outages characteristics of clusters must be read.
 #' @param ror
 #'   vector of areas names for which run of river time series must be read.
 #' @param hydroStorage
@@ -69,10 +71,10 @@
 #' }
 #' 
 #' @export
-readInputTS <- function(load = NULL, thermalAvailabilities = NULL, ror = NULL, 
-                        hydroStorage = NULL, hydroStorageMaxPower = NULL, 
+readInputTS <- function(load = NULL, thermalAvailabilities = NULL, thermalOutages = NULL, 
+                        ror = NULL, hydroStorage = NULL, hydroStorageMaxPower = NULL, 
                         wind = NULL, solar = NULL, misc = NULL,
-                        reserve = NULL, linkCapacity = NULL, opts = simOptions(),
+                        reserve = NULL, linkCapacity = NULL,opts = simOptions(),
                         timeStep = c("hourly", "daily", "weekly", "monthly", "annual"),
                         simplify = TRUE, parallel = FALSE,
                         showProgress = TRUE) {
@@ -88,6 +90,7 @@ readInputTS <- function(load = NULL, thermalAvailabilities = NULL, ror = NULL,
   # Manage special value "all"
   if(identical(load, "all")) load <- opts$areaList
   if(identical(thermalAvailabilities, "all")) thermalAvailabilities <- opts$areasWithClusters
+  if(identical(thermalOutages, "all")) thermalOutages <- opts$areaList
   if(identical(ror, "all")) ror <- opts$areaList
   if(identical(hydroStorage, "all")) hydroStorage <- opts$areaList
   if(identical(hydroStorageMaxPower, "all")) hydroStorageMaxPower <- opts$areaList
@@ -122,6 +125,7 @@ readInputTS <- function(load = NULL, thermalAvailabilities = NULL, ror = NULL,
   # defined in the file "readInputHelpers.R"
   .addOutputToRes("load", load, .importLoad)
   .addOutputToRes("thermalAvailabilities", thermalAvailabilities, .importThermalAvailabilities)
+  .addOutputToRes("thermalOutages", thermalOutages, .importThermalOutages)
   .addOutputToRes("ror", ror, .importROR)
   .addOutputToRes("hydroStorage", hydroStorage, .importHydroStorageInput)
   .addOutputToRes("hydroStorageMaxPower", hydroStorageMaxPower, .importHydroStorageMaxPower)

--- a/man/readInputTS.Rd
+++ b/man/readInputTS.Rd
@@ -4,16 +4,19 @@
 \alias{readInputTS}
 \title{Read Input time series}
 \usage{
-readInputTS(load = NULL, thermalAvailabilities = NULL, ror = NULL,
-  hydroStorage = NULL, hydroStorageMaxPower = NULL, wind = NULL,
-  solar = NULL, misc = NULL, reserve = NULL, linkCapacity = NULL,
-  opts = simOptions(), timeStep = c("hourly", "daily", "weekly", "monthly",
-  "annual"), simplify = TRUE, parallel = FALSE, showProgress = TRUE)
+readInputTS(load = NULL, thermalAvailabilities = NULL,
+  thermalOutages = NULL, ror = NULL, hydroStorage = NULL,
+  hydroStorageMaxPower = NULL, wind = NULL, solar = NULL, misc = NULL,
+  reserve = NULL, linkCapacity = NULL, opts = simOptions(),
+  timeStep = c("hourly", "daily", "weekly", "monthly", "annual"),
+  simplify = TRUE, parallel = FALSE, showProgress = TRUE)
 }
 \arguments{
 \item{load}{vector of areas names for which load time series must be read.}
 
 \item{thermalAvailabilities}{vector of areas names for which thermal availabilities of clusters must be read.}
+
+\item{thermalOutages}{vector of areas names for which thermal outages characteristics of clusters must be read.}
 
 \item{ror}{vector of areas names for which run of river time series must be read.}
 
@@ -91,3 +94,4 @@ matplot(myArea[, - (1:2), with = FALSE], type = "l")
 \code{\link{setSimulationPath}}, \code{\link{readAntares}}, 
 \code{\link{getAreas}}, \code{\link{getLinks}}
 }
+

--- a/tests/testthat/test-readInputTS.R
+++ b/tests/testthat/test-readInputTS.R
@@ -77,5 +77,12 @@ test_that("Link capacity importation works", {
   expect_gt(nrow(input), 0)
   expect_equal(nrow(input) %% (24 * 7 * nweeks), 0)
 })
+
+test_that("Thermal outages importation works", {
+  input <- readInputTS(thermalOutages = "all", showProgress = FALSE)
+  expect_is(input, "antaresDataTable")
+  expect_gt(nrow(input), 0)
+  expect_equal(nrow(input) %% (24 * 7 * nweeks), 0)
+})
 }
 })


### PR DESCRIPTION
Allow to read the data on PO/FO duration and rates as well as NPO_min and NPO_max (minimum and maximum number of unit in maintenance) for each thermal cluster of the given area(s).

`readInputTS(thermalOutages = c("fr", "de"))`

Changes have been made for standard use of the function readInputTS(), **but not for recent changes on hdf5 format**. The complete integration of this new feature might therefore ask for more developments to be taken into account throughout the whole package.

**This feature will be required by the upcoming maintenance optimisation algorithm.**

