### PR TITLE
Fixed bug in getLinks()

### DIFF
--- a/R/getLinks.R
+++ b/R/getLinks.R
@@ -89,9 +89,14 @@ getLinks <- function(areas = NULL, exclude = NULL, opts = simOptions(),
   
   if (namesOnly) return(links$link)
   if (!withDirection) return(links)
-  
-  links <- rbind(links[, .(area = from, link, to = to, direction = 1)], 
-                 links[, .(area = to, link, to = from, direction = -1)])
+
+  outward_links <- links[, .(area = from, link, to = to)]
+  outward_links[, direction := 1]
+
+  inward_links <- links[, .(area = to, link, to = from)]
+  inward_links[, direction := -1]
+
+  links <- rbind(outward_links, inward_links)
   
   links[area %in% areas]
 }

--- a/tests/testthat/test-getLinks.R
+++ b/tests/testthat/test-getLinks.R
@@ -1,0 +1,25 @@
+# Copyright © 2019 RTE Réseau de transport d’électricité
+
+context("Function getLinks")
+
+opts <- list(
+  areaList = c("at", "de", "ie", "es"),
+  linksDef = data.table(
+    link = c("de - ie", "es - de", "es - ie"),
+    from = c("de", "es", "es"),
+    to = c("ie", "de", "ie")
+  )
+)
+
+describe("getLinks", {
+  it("returns the list of links", {
+    expect_equal(getLinks(opts = opts), c("de - ie", "es - de", "es - ie"))
+  })
+  
+  it("works for an area with no links", {
+    expect_equal(
+      nrow(getLinks("at", opts = opts, namesOnly = FALSE, withDirection = TRUE)),
+      0
+    )
+  })
+})


### PR DESCRIPTION
Fixed a bug in `getLinks()`: an error was thrown when calling the function on an area with no links, with certain parameters.
E. g. `getLinks("a", namesOnly = FALSE, withDirection = TRUE) `, `a` being an area with no links.