### PR TITLE
setSimulationPathAPI(): store host and study_id in simulation options

### DIFF
--- a/R/utils_api.R
+++ b/R/utils_api.R
@@ -374,7 +374,9 @@ setSimulationPathAPI <- function(host, study_id, token, simulation = NULL, timeo
   
   res$energyCosts <- .readEnergyCostsAPI(res$inputPath, token, timeout)
   
-  res$typeLoad <- 'api'
+  res$typeLoad <- "api"
+  res$host <- host
+  res$study_id <- study_id
   res$token <- token
   res$timeout <- timeout
   


### PR DESCRIPTION
This will be useful for calling the API later on.