### PR TITLE
Fix for error when 404 output

### DIFF
--- a/R/API-methods.R
+++ b/R/API-methods.R
@@ -52,7 +52,10 @@ api_get <- function(opts, endpoint, ..., default_endpoint = "v1/studies") {
     timeout(opts$timeout),
     ...
   )
-  stop_for_status(result)
+  #fix for skipping 404 when some output is missing
+  url_elements <- strsplit(result$url, "%2F")[[1]]
+  condition_status_check <- !(!is.na(url_elements[4]) & url_elements[4] == "economy" & result$status_code == 404)
+  if (condition_status_check) stop_for_status(result) else warn_for_status(result)
   content(result)
 }
 


### PR DESCRIPTION
Allows to skip missing output (error 404) when using readAntares in API mode
#188 