### PR TITLE
Correction of .importOutput()  to use readAntares with parallel = TRUE in shiny application

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ BREAKING CHANGES (Antares v8.6) :
 BUGFIXES : 
 
 * `setSimulationPathAPI` generate new global parameter `sleep` to add timer to API request
+* Correction of `.importOutput()` to use `readAntares()` with `parallel == TRUE` in shiny application
 
 DATA : 
 

--- a/R/importOutput.R
+++ b/R/importOutput.R
@@ -139,7 +139,7 @@
       res <- llply(
         1:nrow(args), 
         function(i) {
-          incProgress(1/n, detail = paste0("Importing ", folder, " data"))
+          if(showProgress){ incProgress(1/n, detail = paste0("Importing ", folder, " data")) }
           data <- NULL
           try({
             if (!sameNames) {


### PR DESCRIPTION
Correction of `.importOutput()`  to use `readAntares()` with `parallel == TRUE` in shiny application :
Add the condition `showProgress == TRUE` to execute `incProgress()` line in `plyr::llply()`