### PR TITLE
Take into account ST storage in .giveSize()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ BUGFIXES :
 * `api_get()` : add warn_for_status in importFrom section
 * `readAntares()` : In disk mode, return all the available columns for a short-term storage output and match the column with the content
 * `.importOutput()` : check if output file exists in API mode (`.check_output_files_existence()`)
+* `.giveSize()` : take into account ST clusters in the size computing and use enabled == TRUE or empty enabled for enabled clusters and ST clusters 
 
 BREAKING CHANGES :  
 

--- a/R/giveSize.R
+++ b/R/giveSize.R
@@ -29,7 +29,7 @@ setRam <- function(x){
 #'
 #' @noRd
 .giveSize <- function(opts, areas = NULL, links = NULL,
-                      clusters = NULL, districts = NULL, select = NULL, mcYears = NULL,
+                      clusters = NULL, clustersST = NULL, districts = NULL, select = NULL, mcYears = NULL,
                       timeStep = "hourly", misc = FALSE, thermalAvailabilities = FALSE,
                       hydroStorage = FALSE, hydroStorageMaxPower = FALSE, reserve = FALSE,
                       linkCapacity = FALSE, mustRun = FALSE, thermalModulation = FALSE){
@@ -68,7 +68,7 @@ setRam <- function(x){
   }
   
   nbTid <- nbTid
-  if(is.null(areas) & is.null(links) & is.null(clusters) & is.null(districts)){
+  if(is.null(areas) & is.null(links) & is.null(clusters) & is.null(districts) & is.null(clustersST)){
     areas <- "all"
   }
   
@@ -178,13 +178,13 @@ setRam <- function(x){
       enabled <- TRUE
       if("enabled" %in% names(clusWithData))
       {
-        clusWithData <- clusWithData[is.na(enabled)]
+        clusWithData <- clusWithData[is.na(enabled) | enabled]
       }
     }else{
       clustersS <- clusters
       if("enabled" %in% names(clusWithData))
       {
-        clusWithData <- clusWithData[is.na(enabled)]
+        clusWithData <- clusWithData[is.na(enabled) | enabled]
       }
       if("area" %in% names(clusWithData))
       {
@@ -204,6 +204,33 @@ setRam <- function(x){
   nbRowClusters <- nbTid * nbMc * nrow(clusWithData) * ( nbColcl + nbIdCols)
   clSize <- sizeObjectCl * nbRowClusters / 1024 ^2
   
-  linksSize + areasSize + disSize + clSize
+  # ST clusters size
+  clusSTWithData <- data.table()
+  if(!is.null(clustersST))
+  {
+    clusSTWithData  <- tryCatch(readClusterSTDesc(opts = opts), error = function(e) data.table())
+    if("all" %in% clustersST){
+      enabled <- TRUE
+      if("enabled" %in% names(clusSTWithData))
+      {
+        clusSTWithData <- clusSTWithData[is.na(enabled) | enabled]
+      }
+    }else{
+      clustersS <- clustersST
+      if("enabled" %in% names(clusSTWithData))
+      {
+        clusSTWithData <- clusSTWithData[is.na(enabled) | enabled]
+      }
+      if("area" %in% names(clusSTWithData))
+      {
+      clusSTWithData <- clusSTWithData[ area %in% clustersS]
+      }
+    }
+  }
+  
+  nbColclST <- 4
+  nbRowClustersST <- nbTid * nbMc * nrow(clusSTWithData) * ( nbColclST + nbIdCols)
+  clSTSize <- sizeObjectCl * nbRowClustersST / 1024 ^2
+  
+  linksSize + areasSize + disSize + clSize + clSTSize
 }
-

--- a/R/readAntares.R
+++ b/R/readAntares.R
@@ -243,7 +243,7 @@ readAntares <- function(areas = NULL, links = NULL, clusters = NULL,
   
   ##Controle size of data load
   size <- .giveSize(opts = opts, areas = areas, links = links, 
-                    clusters = clusters, districts = districts, select = select,
+                    clusters = clusters, clustersST = clustersST, districts = districts, select = select,
                     mcYears = mcYears ,timeStep = timeStep, misc = misc, thermalAvailabilities = thermalAvailabilities,
                     hydroStorage = hydroStorage, hydroStorageMaxPower = hydroStorageMaxPower, reserve = reserve,
                     linkCapacity = linkCapacity, mustRun = mustRun, thermalModulation = thermalModulation)/1024

--- a/tests/testthat/test-giveSize.R
+++ b/tests/testthat/test-giveSize.R
@@ -1,0 +1,156 @@
+# v710----
+
+## Thermal ----
+test_that("Size is positive", {
+  opts <- list(
+    "inputPath"=tempdir(),
+    "typeLoad"='not_api',
+    "areaList" = c("fr","de"),
+    "antaresVersion" = 880,
+    "mcYears" = seq(1,1000),
+    "timeIdMax" = 8736,
+    "timeIdMin" = 1
+  )
+  
+  # enabled = true 3*
+  ini_clusters <- c(
+    "[fr_cl_1]",
+    "name = fr_cl_1",
+    "unitcount = 120",
+    "nominalcapacity = 2",
+    "enabled = true",
+    "",
+    "[fr_cl_2]",
+    "name = fr_cl_2",
+    "unitcount = 2",
+    "nominalcapacity = 5",
+    "enabled = true",
+    "",
+    "[fr_cl_3]",
+    "name = fr_cl_3",
+    "unitcount = 20",
+    "nominalcapacity = 48",
+    "enabled = true",
+    ""
+  )
+  
+  ini_clusters_st <- c(
+    "[de_st_1]",
+    "name = de_st_1",
+    "unitcount = 120",
+    "nominalcapacity = 2",
+    "enabled = true",
+    "",
+    "[de_st_2]",
+    "name = de_st_2",
+    "unitcount = 2",
+    "nominalcapacity = 5",
+    "enabled = false",
+    "",
+    "[de_st_3]",
+    "name = de_st_3",
+    "unitcount = 20",
+    "nominalcapacity = 48",
+    "enabled = true",
+    ""
+  )
+  
+  clusters_fr_path <- file.path(tempdir(),"thermal", "clusters", "fr")
+  suppressWarnings(dir.create(clusters_fr_path, recursive = TRUE, showWarnings = FALSE))
+  writeLines(ini_clusters, file.path(clusters_fr_path,"list.ini"))
+  
+  clusters_st_de_path <- file.path(tempdir(),"st-storage", "clusters", "de")
+  suppressWarnings(dir.create(clusters_st_de_path, recursive = TRUE, showWarnings = FALSE))
+  writeLines(ini_clusters_st, file.path(clusters_st_de_path,"list.ini"))
+  
+  size <- .giveSize(opts = opts, clusters = "fr", timeStep = "hourly", mcYears = "all")
+  expected_size <- (8735 * 1000 * 3 * 11 * 5.5) / 1024^2
+  testthat::expect_equal(size, expected_size)
+  
+  size <- .giveSize(opts = opts, clustersST = "de", timeStep = "hourly", mcYears = "all")
+  expected_size <- (8735 * 1000 * 2 * 11 * 5.5) / 1024^2
+  testthat::expect_equal(size, expected_size)
+  
+  size <- .giveSize(opts = opts, clusters = "fr", clustersST = "de", timeStep = "hourly", mcYears = "all")
+  expected_size <- (8735 * 1000 * 3 * 11 * 5.5) / 1024^2 + (8735 * 1000 * 2 * 11 * 5.5) / 1024^2
+  testthat::expect_equal(size, expected_size)
+  
+  # enabled = true 2* enabled = false 1*
+  ini_clusters <- c(
+    "[fr_cl_1]",
+    "name = fr_cl_1",
+    "unitcount = 120",
+    "nominalcapacity = 2",
+    "enabled = true",
+    "",
+    "[fr_cl_2]",
+    "name = fr_cl_2",
+    "unitcount = 2",
+    "nominalcapacity = 5",
+    "enabled = true",
+    "",
+    "[fr_cl_3]",
+    "name = fr_cl_3",
+    "unitcount = 20",
+    "nominalcapacity = 48",
+    "enabled = false",
+    ""
+  )
+  
+  writeLines(ini_clusters, file.path(clusters_fr_path,"list.ini"))
+  
+  size <- .giveSize(opts = opts, clusters = "fr", timeStep = "hourly", mcYears = "all")
+  expected_size <- (8735 * 1000 * 2 * 11 * 5.5) / 1024^2
+  testthat::expect_equal(size, expected_size)
+  
+  # enabled empty 3*
+  ini_clusters <- c(
+    "[fr_cl_1]",
+    "name = fr_cl_1",
+    "unitcount = 120",
+    "nominalcapacity = 2",
+    "",
+    "[fr_cl_2]",
+    "name = fr_cl_2",
+    "unitcount = 2",
+    "nominalcapacity = 5",
+    "",
+    "[fr_cl_3]",
+    "name = fr_cl_3",
+    "unitcount = 20",
+    "nominalcapacity = 48",
+    ""
+  )
+  
+  writeLines(ini_clusters, file.path(clusters_fr_path,"list.ini"))
+  
+  size <- .giveSize(opts = opts, clusters = "fr", timeStep = "hourly", mcYears = "all")
+  expected_size <- (8735 * 1000 * 3 * 11 * 5.5) / 1024^2
+  testthat::expect_equal(size, expected_size)
+  
+  # enabled empty 2* enabled = true 1*
+  ini_clusters <- c(
+    "[fr_cl_1]",
+    "name = fr_cl_1",
+    "unitcount = 120",
+    "nominalcapacity = 2",
+    "",
+    "[fr_cl_2]",
+    "name = fr_cl_2",
+    "unitcount = 2",
+    "nominalcapacity = 5",
+    "",
+    "[fr_cl_3]",
+    "name = fr_cl_3",
+    "unitcount = 20",
+    "nominalcapacity = 48",
+    "enabled = true",
+    ""
+  )
+  
+  writeLines(ini_clusters, file.path(clusters_fr_path,"list.ini"))
+  
+  size <- .giveSize(opts = opts, clusters = "fr", timeStep = "hourly", mcYears = "all")
+  expected_size <- (8735 * 1000 * 3 * 11 * 5.5) / 1024^2
+  testthat::expect_equal(size, expected_size)
+})

--- a/tests/testthat/test-giveSize.R
+++ b/tests/testthat/test-giveSize.R
@@ -1,7 +1,5 @@
-# v710----
 
-## Thermal ----
-test_that("Size is positive", {
+test_that("Check the size of the object to get", {
   opts <- list(
     "inputPath"=tempdir(),
     "typeLoad"='not_api',


### PR DESCRIPTION
- ST storage are not taken into account in the computing of the size of the outputs.
- Add enabled == TRUE to catch the enabled clusters