### PR TITLE
Fix setSimulationPath() version number returned 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: antaresRead
 Type: Package
 Title: Import, Manipulate and Explore the Results of an 'Antares' Simulation
-Version: 2.9.0.9000
+Version: 2.9.1.9000 
 Authors@R: c(
     person("Tatiana", "Vargas", email = "tatiana.vargas@rte-france.com", role = c("aut", "cre")),
     person("Jalal-Edine", "ZAWAM", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,23 @@
 > Copyright © 2016 RTE Réseau de transport d’électricité
 
 
-# antaresRead 2.9.0.9000
-(cf. Antares v9 changelog)  
+# antaresRead 2.9.1.9000  
+
+NEW FEATURES:  
+ 
+* `readBindingConstraints()` : has a new parameter `'with_time_series'` (default to `TRUE`) to enable or disable the time series reading (optimization)
+ 
+BUGFIXES :  
+ 
+* `api_get() / api_post () / api_put() / api_delete()` : treat case when default_endpoint provided is empty  
+* `setSimulationPathAPI()` : The version number returned for a study >= 9.2 (9.2*100) is in fact considered by R as <920 with a precision of `-1.136868e-13`. This falsifies the version number checks (atypical error depending on machine precision, see R doc `?double`)
+ 
+BREAKING CHANGES :  
+ 
+* `setSimulationPathAPI()` : sets timeout to 600s by default. 600s is the default value in Antares Web.
+
+
+# antaresRead 2.9.0
 
 NEW FEATURES:  
 

--- a/R/setSimulationPath.R
+++ b/R/setSimulationPath.R
@@ -709,7 +709,7 @@ setSimulationPath <- function(path, simulation = NULL) {
          call. = FALSE)
   
   # convert to numeric for package understanding
-  num_version <- as.numeric(antares_version)*100
+  num_version <- round(as.numeric(antares_version)*100)
   
   return(num_version)
 }

--- a/tests/testthat/test-setSimulationPath.R
+++ b/tests/testthat/test-setSimulationPath.R
@@ -265,3 +265,27 @@ test_that("read new format version from study", {
   # test right conversion for package
   expect_equal(study$antaresVersion, 900)
 })
+
+# v920----
+test_that("Check version pb (9.2*100)<920 TRUE ?", {
+  # check `?double` (details section Double-precision values)
+  # 9.2*100)<920 return TRUE localy 
+  # (9.2*100)-920 return -1.136868e-13 
+  # check version on 9.2 don't work 
+  
+  # context
+  expect_error(
+    expect_false((9.2*100)<920)
+  )
+  
+  expect_error(
+    expect_identical((9.2*100)-920, 0)
+  )
+  
+  expect_identical(round(9.2*100)-920, 0)
+  
+  # just test private function
+  expect_false(
+    .transform_antares_version("9.2")<920
+  )
+})


### PR DESCRIPTION
Bump to `2.9.1.9000`. 

From study version >= 9.2, `setSimulationPath()` return `as.numeric("9.2")*100 ` but it's not an `integer` (Double-Precision Vectors).

So `as.numeric("9.2")*100 <920` return `TRUE`.

- fix `setSimulationPath()` version number returned for a study >= 9.0