### PR TITLE
Use a specific endpoint to get the list of the outputs of a study

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 > Copyright © 2016 RTE Réseau de transport d’électricité
 
+# antaresRead 3.0.2.9000
+
+NEW FEATURES :
+* `.getPathsAPI()` uses a specific endpoint to get the list of the outputs of a study.
+
 # antaresRead 3.0.1
 
 BUGFIXES :

--- a/R/setSimulationPathAPI.R
+++ b/R/setSimulationPathAPI.R
@@ -1,6 +1,6 @@
 .getPathsAPI <- function(host, token, study_id, simulation, ...){
   
-	simNames <- NULL
+  simNames <- NULL
   path <- paste0(host, "/v1/studies/", study_id)
   path <- gsub("[/\\]$", "", path)
   path <- paste0(path, "/raw?path=")

--- a/R/setSimulationPathAPI.R
+++ b/R/setSimulationPathAPI.R
@@ -1,13 +1,17 @@
-.getPathsAPI <- function(host, study_id, simulation, ...){
-  simNames <- NULL
+.getPathsAPI <- function(host, token, study_id, simulation, ...){
+  
+	simNames <- NULL
   path <- paste0(host, "/v1/studies/", study_id)
   path <- gsub("[/\\]$", "", path)
   path <- paste0(path, "/raw?path=")
   inputPath <- file.path(path,  "input")
   outputPath <- file.path(path,  "output")
   if(is.null(simulation) | (!is.null(simulation) && !simulation %in% c(0, "input"))){
-    outputContent <- names(read_secure_json(paste0(outputPath, "&depth=4"), ...))
-    simNames <- setdiff(basename(outputContent), c("maps", "logs"))
+    config <- c(httr::add_headers(Authorization = paste("Bearer ", token)))
+    result <- httr::GET(url = URLencode(paste(c(host, "v1/studies", study_id, "outputs"), collapse = "/")),
+                  config = config
+                  )
+    simNames <- sapply(content(result), "[[", "name")
   }
   if (length(simNames) == 0) {
     if (length(simulation) > 0 && !simulation %in% c(0, "input")) {

--- a/tests/testthat/test-read_st_constraints.R
+++ b/tests/testthat/test-read_st_constraints.R
@@ -324,7 +324,7 @@ test_that("Check with cluster without time series",{
     use.names = FALSE)
   expect_equal(unique(struct_names), c("properties", "values" ))
 
-  test_that("Check wiyhout values",{
+  test_that("Check without values",{
     # given
 
     # cluster without ts
@@ -332,7 +332,9 @@ test_that("Check with cluster without time series",{
 
     # then
     expect_equal(full_st_constraints$be$be_storage_2$values,
-                 data.table())
+                 data.table(),
+                 ignore.attr = TRUE
+                 )
   })
 
   unlink(opts$inputPath, recursive = TRUE)


### PR DESCRIPTION
Avoid endpoint raw in output due to a change in Antares Web